### PR TITLE
Add support for jdbi3. Require Java 8+.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,11 @@
             <artifactId>jdbi</artifactId>
             <version>${jdbi.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-core</artifactId>
+            <version>${jdbi3.version}</version>
+        </dependency>
 
         <!-- testing dependencies: -->
         <dependency>
@@ -145,10 +150,11 @@
 
     <properties>
         <jdbi.version>2.74</jdbi.version>
+        <jdbi3.version>3.5.1</jdbi3.version>
         <opentracing.version>0.31.0</opentracing.version>
         <mysql.version>5.1.6</mysql.version>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <issueManagement>

--- a/src/main/java/io/opentracing/contrib/jdbi3/OpenTracingCollector.java
+++ b/src/main/java/io/opentracing/contrib/jdbi3/OpenTracingCollector.java
@@ -1,0 +1,202 @@
+package io.opentracing.contrib.jdbi3;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import org.jdbi.v3.core.statement.SqlStatement;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.core.statement.TimingCollector;
+
+import java.util.HashMap;
+
+/**
+ * OpenTracingCollector is a Jdbi TimingCollector that creates OpenTracing Spans for each Jdbi SQLStatement.
+ *
+ * <p>Example usage:
+ * <pre>{@code
+ * io.opentracing.Tracer tracer = ...;
+ * Jdbi dbi = ...;
+ *
+ * // One time only: bind OpenTracing to the Jdbi instance as a TimingCollector.
+ * dbi.setTimingCollector(new OpenTracingCollector(tracer));
+ *
+ * // Elsewhere, anywhere a `Handle` is available:
+ * Handle handle = ...;
+ * Span parentSpan = ...;  // optional
+ *
+ * // Create statements as usual with your `handle` instance.
+ *  Query<Map<String, Object>> statement = handle.createQuery("SELECT COUNT(*) FROM accounts");
+ *
+ * // If a parent Span is available, establish the relationship via setParent.
+ * OpenTracingCollector.setParent(statement, parent);
+ *
+ * // Use Jdbi as per usual, and Spans will be created for every SQLStatement automatically.
+ * List<Map<String, Object>> results = statement.list();
+ * }</pre>
+ */
+@SuppressWarnings("WeakerAccess")
+@Deprecated
+public class OpenTracingCollector implements TimingCollector {
+    public final static String PARENT_SPAN_ATTRIBUTE_KEY = "io.opentracing.parent";
+
+    private final Tracer tracer;
+    private final SpanDecorator spanDecorator;
+    private final ActiveSpanSource activeSpanSource;
+    private final TimingCollector next;
+
+    public OpenTracingCollector(Tracer tracer) {
+        this(tracer, SpanDecorator.DEFAULT);
+    }
+
+    /**
+     * @param tracer the OpenTracing tracer to trace Jdbi calls.
+     * @param next a timing collector to "chain" to. When collect is called on
+     *             this TimingCollector, collect will also be called on 'next'
+     */
+    @SuppressWarnings("unused")
+    public OpenTracingCollector(Tracer tracer, TimingCollector next) {
+        this(tracer, SpanDecorator.DEFAULT, null, null);
+    }
+
+    public OpenTracingCollector(Tracer tracer, SpanDecorator spanDecorator) {
+        this(tracer, spanDecorator, null);
+    }
+
+    public OpenTracingCollector(Tracer tracer, ActiveSpanSource spanSource) {
+        this(tracer, SpanDecorator.DEFAULT, spanSource);
+    }
+
+    public OpenTracingCollector(Tracer tracer, SpanDecorator spanDecorator, ActiveSpanSource activeSpanSource) {
+        this(tracer, spanDecorator, activeSpanSource, null);
+    }
+
+    /**
+     * @param tracer the OpenTracing tracer to trace Jdbi calls.
+     * @param spanDecorator the SpanDecorator used to name and decorate spans.
+     *                      @see SpanDecorator
+     * @param activeSpanSource a source that can provide the currently active
+     *                         span when creating a child span.
+     *                         @see ActiveSpanSource
+     * @param next a timing collector to "chain" to. When collect is called on
+     *             this TimingCollector, collect will also be called on 'next'
+     */
+    public OpenTracingCollector(Tracer tracer, SpanDecorator spanDecorator, ActiveSpanSource activeSpanSource, TimingCollector next) {
+        this.tracer = tracer;
+        this.spanDecorator = spanDecorator;
+        this.activeSpanSource = activeSpanSource;
+        this.next = next;
+    }
+
+    public void collect(long elapsedNanos, StatementContext statementContext) {
+        long nowMicros = System.currentTimeMillis() * 1000;
+        Tracer.SpanBuilder builder = tracer
+                .buildSpan(spanDecorator.generateOperationName(statementContext))
+                .withStartTimestamp(nowMicros - (elapsedNanos / 1000));
+        Span parent = (Span)statementContext.getAttribute(PARENT_SPAN_ATTRIBUTE_KEY);
+        if (parent == null && this.activeSpanSource != null) {
+            parent = this.activeSpanSource.activeSpan(statementContext);
+        }
+        if (parent != null) {
+            builder = builder.asChildOf(parent);
+        }
+        Span collectSpan = builder.start();
+        spanDecorator.decorateSpan(collectSpan, elapsedNanos, statementContext);
+        try {
+
+            HashMap<String, String> values = new HashMap<>();
+            values.put("event", "SQL query finished");
+            values.put("db.statement", statementContext.getRawSql());
+            collectSpan.log(nowMicros, values);
+        } finally {
+            collectSpan.finish(nowMicros);
+        }
+
+        if (next != null) {
+            next.collect(elapsedNanos, statementContext);
+        }
+    }
+
+    /**
+     * Establish an explicit parent relationship for the (child) Span associated with a SQLStatement.
+     *
+     * @param statement the Jdbi SQLStatement which will act as the child of `parent`
+     * @param parent the parent Span for `statement`
+     */
+    public static void setParent(SqlStatement<?> statement, Span parent) {
+        statement.getContext().define(PARENT_SPAN_ATTRIBUTE_KEY, parent);
+    }
+
+    /**
+     * SpanDecorator allows the OpenTracingCollector user to control the precise naming and decoration of OpenTracing
+     * Spans emitted by the collector.
+     *
+     * @see OpenTracingCollector#OpenTracingCollector(Tracer, SpanDecorator)
+     */
+    public interface SpanDecorator {
+        SpanDecorator DEFAULT = new SpanDecorator() {
+            public String generateOperationName(StatementContext ctx) {
+                return "Jdbi Statement";
+            }
+
+            @Override
+            public void decorateSpan(Span jdbiSpan, long elapsedNanos, StatementContext ctx) {
+                // (by default, do nothing)
+            }
+        };
+
+        /**
+         * Transform an Jdbi StatementContext into an OpenTracing Span operation name.
+         *
+         * @param ctx the StatementContext passed to TimingCollector.collect()
+         * @return an operation name suitable for the associated OpenTracing Span
+         */
+        String generateOperationName(StatementContext ctx);
+
+        /**
+         * Decorate the given span with additional tags or logs. Implementations may or may not need to refer
+         * to the StatementContext.
+         *
+         * @param jdbiSpan the Jdbi Span to decorate (before `finish` is called)
+         * @param elapsedNanos the elapsedNanos passed to TimingCollector.collect()
+         * @param ctx the StatementContext passed to TimingCollector.collect()
+         */
+        void decorateSpan(Span jdbiSpan, long elapsedNanos, StatementContext ctx);
+    }
+
+    /**
+     * An abstract API that allows the OpenTracingCollector to customize how parent Spans are discovered.
+     *
+     * For instance, if Spans are stored in a thread-local variable, an ActiveSpanSource could access them like so:
+     * <p>Example usage:
+     * <pre>{@code
+     * public class SomeClass {
+     *     // Thread local variable containing each thread's ID
+     *     private static final ThreadLocal<Span> activeSpan =
+     *         new ThreadLocal<Span>() {
+     *             protected Integer initialValue() {
+     *                 return null;
+     *             }
+     *         };
+     * };
+     *
+     * ... elsewhere ...
+     * ActiveSpanSource spanSource = new ActiveSpanSource() {
+     *     public Span activeSpan(StatementContext ctx) {
+     *         // (In this example we ignore `ctx` entirely)
+     *         return activeSpan.get();
+     *     }
+     * };
+     * OpenTracingCollector otColl = new OpenTracingCollector(tracer, spanSource);
+     * ...
+     * }</pre>
+     */
+    public interface ActiveSpanSource {
+        /**
+         * Get the active Span (to use as a parent for any Jdbi Spans). Implementations may or may not need to refer
+         * to the StatementContext.
+         *
+         * @param ctx the StatementContext that needs to be collected and traced
+         * @return the currently active Span (for this thread, etc), or null if no such Span could be found.
+         */
+        Span activeSpan(StatementContext ctx);
+    }
+}

--- a/src/main/java/io/opentracing/contrib/jdbi3/OpenTracingCollectorWithSqlLogger.java
+++ b/src/main/java/io/opentracing/contrib/jdbi3/OpenTracingCollectorWithSqlLogger.java
@@ -1,0 +1,205 @@
+package io.opentracing.contrib.jdbi3;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import org.jdbi.v3.core.statement.SqlLogger;
+import org.jdbi.v3.core.statement.SqlStatement;
+import org.jdbi.v3.core.statement.StatementContext;
+
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+
+/**
+ * OpenTracingCollector is a Jdbi SqlLogger that creates OpenTracing Spans for each Jdbi SQLStatement.
+ *
+ * <p>Example usage:
+ * <pre>{@code
+ * io.opentracing.Tracer tracer = ...;
+ * Jdbi dbi = ...;
+ *
+ * // One time only: bind OpenTracing to the Jdbi instance as a SqlLogger.
+ * dbi.setSqlLogger(new OpenTracingCollector(tracer));
+ *
+ * // Elsewhere, anywhere a `Handle` is available:
+ * Handle handle = ...;
+ * Span parentSpan = ...;  // optional
+ *
+ * // Create statements as usual with your `handle` instance.
+ *  Query<Map<String, Object>> statement = handle.createQuery("SELECT COUNT(*) FROM accounts");
+ *
+ * // If a parent Span is available, establish the relationship via setParent.
+ * OpenTracingCollector.setParent(statement, parent);
+ *
+ * // Use Jdbi as per usual, and Spans will be created for every SQLStatement automatically.
+ * List<Map<String, Object>> results = statement.list();
+ * }</pre>
+ */
+@SuppressWarnings("WeakerAccess,unused")
+public class OpenTracingCollectorWithSqlLogger implements SqlLogger {
+    public final static String PARENT_SPAN_ATTRIBUTE_KEY = "io.opentracing.parent";
+
+    private final Tracer tracer;
+    private final SpanDecorator spanDecorator;
+    private final ActiveSpanSource activeSpanSource;
+    private final SqlLogger next;
+
+    public OpenTracingCollectorWithSqlLogger(Tracer tracer) {
+        this(tracer, SpanDecorator.DEFAULT);
+    }
+
+    /**
+     * @param tracer the OpenTracing tracer to trace Jdbi calls.
+     * @param next a timing collector to "chain" to. When collect is called on
+     *             this SqlLogger, collect will also be called on 'next'
+     */
+    @SuppressWarnings("unused")
+    public OpenTracingCollectorWithSqlLogger(Tracer tracer, SqlLogger next) {
+        this(tracer, SpanDecorator.DEFAULT, null, null);
+    }
+
+    public OpenTracingCollectorWithSqlLogger(Tracer tracer, SpanDecorator spanDecorator) {
+        this(tracer, spanDecorator, null);
+    }
+
+    public OpenTracingCollectorWithSqlLogger(Tracer tracer, ActiveSpanSource spanSource) {
+        this(tracer, SpanDecorator.DEFAULT, spanSource);
+    }
+
+    public OpenTracingCollectorWithSqlLogger(Tracer tracer, SpanDecorator spanDecorator, ActiveSpanSource activeSpanSource) {
+        this(tracer, spanDecorator, activeSpanSource, null);
+    }
+
+    /**
+     * @param tracer the OpenTracing tracer to trace Jdbi calls.
+     * @param spanDecorator the SpanDecorator used to name and decorate spans.
+     *                      @see SpanDecorator
+     * @param activeSpanSource a source that can provide the currently active
+     *                         span when creating a child span.
+     *                         @see ActiveSpanSource
+     * @param next a timing collector to "chain" to. When collect is called on
+     *             this SqlLogger, collect will also be called on 'next'
+     */
+    public OpenTracingCollectorWithSqlLogger(Tracer tracer, SpanDecorator spanDecorator, ActiveSpanSource activeSpanSource, SqlLogger next) {
+        this.tracer = tracer;
+        this.spanDecorator = spanDecorator;
+        this.activeSpanSource = activeSpanSource;
+        this.next = next;
+    }
+
+    @Override
+    public void logAfterExecution(StatementContext statementContext) {
+        long nowMicros = System.currentTimeMillis() * 1000;
+        Tracer.SpanBuilder builder = tracer
+            .buildSpan(spanDecorator.generateOperationName(statementContext))
+            .withStartTimestamp(nowMicros - (statementContext.getElapsedTime(ChronoUnit.NANOS) / 1000));
+        Span parent = (Span)statementContext.getAttribute(PARENT_SPAN_ATTRIBUTE_KEY);
+        if (parent == null && this.activeSpanSource != null) {
+            parent = this.activeSpanSource.activeSpan(statementContext);
+        }
+        if (parent != null) {
+            builder = builder.asChildOf(parent);
+        }
+        Span collectSpan = builder.start();
+        spanDecorator.decorateSpan(collectSpan, statementContext.getElapsedTime(ChronoUnit.NANOS), statementContext);
+        try {
+
+            HashMap<String, String> values = new HashMap<>();
+            values.put("event", "SQL query finished");
+            values.put("db.statement", statementContext.getRawSql());
+            collectSpan.log(nowMicros, values);
+        } finally {
+            collectSpan.finish(nowMicros);
+        }
+
+        if (next != null) {
+            next.logAfterExecution(statementContext);
+        }
+    }
+
+
+
+    /**
+     * Establish an explicit parent relationship for the (child) Span associated with a SQLStatement.
+     *
+     * @param statement the Jdbi SQLStatement which will act as the child of `parent`
+     * @param parent the parent Span for `statement`
+     */
+    public static void setParent(SqlStatement<?> statement, Span parent) {
+        statement.getContext().define(PARENT_SPAN_ATTRIBUTE_KEY, parent);
+    }
+
+    /**
+     * SpanDecorator allows the OpenTracingCollector user to control the precise naming and decoration of OpenTracing
+     * Spans emitted by the collector.
+     *
+     * @see OpenTracingCollectorWithSqlLogger#OpenTracingCollectorWithSqlLogger(Tracer, SpanDecorator)
+     */
+    public interface SpanDecorator {
+        SpanDecorator DEFAULT = new SpanDecorator() {
+            public String generateOperationName(StatementContext ctx) {
+                return "Jdbi Statement";
+            }
+
+            @Override
+            public void decorateSpan(Span jdbiSpan, long elapsedNanos, StatementContext ctx) {
+                // (by default, do nothing)
+            }
+        };
+
+        /**
+         * Transform an Jdbi StatementContext into an OpenTracing Span operation name.
+         *
+         * @param ctx the StatementContext passed to SqlLogger.collect()
+         * @return an operation name suitable for the associated OpenTracing Span
+         */
+        String generateOperationName(StatementContext ctx);
+
+        /**
+         * Decorate the given span with additional tags or logs. Implementations may or may not need to refer
+         * to the StatementContext.
+         *
+         * @param jdbiSpan the Jdbi Span to decorate (before `finish` is called)
+         * @param elapsedNanos the elapsedNanos passed to SqlLogger.collect()
+         * @param ctx the StatementContext passed to SqlLogger.collect()
+         */
+        void decorateSpan(Span jdbiSpan, long elapsedNanos, StatementContext ctx);
+    }
+
+    /**
+     * An abstract API that allows the OpenTracingCollector to customize how parent Spans are discovered.
+     *
+     * For instance, if Spans are stored in a thread-local variable, an ActiveSpanSource could access them like so:
+     * <p>Example usage:
+     * <pre>{@code
+     * public class SomeClass {
+     *     // Thread local variable containing each thread's ID
+     *     private static final ThreadLocal<Span> activeSpan =
+     *         new ThreadLocal<Span>() {
+     *             protected Integer initialValue() {
+     *                 return null;
+     *             }
+     *         };
+     * };
+     *
+     * ... elsewhere ...
+     * ActiveSpanSource spanSource = new ActiveSpanSource() {
+     *     public Span activeSpan(StatementContext ctx) {
+     *         // (In this example we ignore `ctx` entirely)
+     *         return activeSpan.get();
+     *     }
+     * };
+     * OpenTracingCollector otColl = new OpenTracingCollector(tracer, spanSource);
+     * ...
+     * }</pre>
+     */
+    public interface ActiveSpanSource {
+        /**
+         * Get the active Span (to use as a parent for any Jdbi Spans). Implementations may or may not need to refer
+         * to the StatementContext.
+         *
+         * @param ctx the StatementContext that needs to be collected and traced
+         * @return the currently active Span (for this thread, etc), or null if no such Span could be found.
+         */
+        Span activeSpan(StatementContext ctx);
+    }
+}

--- a/src/test/java/io/opentracing/contrib/jdbi3/OpenTracingCollectorTest.java
+++ b/src/test/java/io/opentracing/contrib/jdbi3/OpenTracingCollectorTest.java
@@ -1,0 +1,176 @@
+package io.opentracing.contrib.jdbi3;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.statement.Query;
+import org.jdbi.v3.core.statement.SqlLogger;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+// REQUIRES: a mysql database running on localhost.
+public class OpenTracingCollectorTest {
+    private static Jdbi getLocalJdbi() {
+        return getLocalJdbi("");
+    }
+    private static Jdbi getLocalJdbi(String dbName) {
+        return Jdbi.create("jdbc:mysql://127.0.0.1/" + dbName, "root", "");
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        Class.forName("com.mysql.jdbc.Driver");
+        {
+            Jdbi dbi = getLocalJdbi();
+            Handle handle = dbi.open();
+            handle.execute("CREATE DATABASE IF NOT EXISTS _jdbi_test_db");
+        }
+        {
+            Jdbi dbi = getLocalJdbi("_jdbi_test_db");
+            Handle handle = dbi.open();
+            handle.execute("CREATE TABLE IF NOT EXISTS accounts (id BIGINT AUTO_INCREMENT, PRIMARY KEY (id))");
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        Jdbi dbi = getLocalJdbi();
+        Handle handle = dbi.open();
+        handle.execute("DROP DATABASE _jdbi_test_db");
+    }
+
+    @Test
+    public void testParentage() {
+        MockTracer tracer = new MockTracer();
+        Jdbi dbi = getLocalJdbi("_jdbi_test_db");
+        dbi.setSqlLogger(new OpenTracingCollectorWithSqlLogger(tracer));
+
+        // The actual Jdbi code:
+        {
+            Handle handle = dbi.open();
+            Tracer.SpanBuilder parentBuilder = tracer.buildSpan("parent span");
+            Span parent = parentBuilder.start();
+            Query statement = handle.createQuery("SELECT COUNT(*) FROM accounts");
+            OpenTracingCollectorWithSqlLogger.setParent(statement, parent);
+
+            // A Span will be created automatically and will reference `parent`.
+            List<Map<String, Object>> results = statement.mapToMap().list();
+            parent.finish();
+        }
+
+        List<MockSpan> finishedSpans = tracer.finishedSpans();
+        assertEquals(finishedSpans.size(), 2);
+        MockSpan parentSpan = finishedSpans.get(1);
+        MockSpan childSpan = finishedSpans.get(0);
+        assertEquals("parent span", parentSpan.operationName());
+        assertEquals("Jdbi Statement", childSpan.operationName());
+        assertEquals(parentSpan.context().traceId(), childSpan.context().traceId());
+        assertEquals(parentSpan.context().spanId(), childSpan.parentId());
+    }
+
+    @Test
+    // Requires a mysql database running on localhost.
+    public void testDecorations() {
+        MockTracer tracer = new MockTracer();
+        Jdbi dbi = getLocalJdbi("_jdbi_test_db");
+        dbi.setSqlLogger(new OpenTracingCollectorWithSqlLogger(tracer, new OpenTracingCollectorWithSqlLogger.SpanDecorator(){
+            @Override
+            public String generateOperationName(StatementContext ctx) {
+                return "custom name";
+            }
+
+            @Override
+            public void decorateSpan(Span jdbiSpan, long elapsedNanos, StatementContext ctx) {
+                jdbiSpan.setTag("testTag", "testVal");
+            }
+        } ));
+
+        // The actual Jdbi code:
+        {
+            Handle handle = dbi.open();
+            Query statement = handle.createQuery("SELECT COUNT(*) FROM accounts");
+            List<Map<String, Object>> results = statement.mapToMap().list();
+        }
+
+        List<MockSpan> finishedSpans = tracer.finishedSpans();
+        assertEquals(finishedSpans.size(), 1);
+        MockSpan span = finishedSpans.get(0);
+        assertEquals("custom name", span.operationName());
+        assertEquals("testVal", span.tags().get("testTag"));
+    }
+
+    @Test
+    // Requires a mysql database running on localhost.
+    public void testActiveSpanSource() {
+        MockTracer tracer = new MockTracer();
+        Jdbi dbi = getLocalJdbi("_jdbi_test_db");
+
+        Tracer.SpanBuilder parentBuilder = tracer.buildSpan("active span");
+        final Span activeSpan = parentBuilder.start();
+        dbi.setSqlLogger(new OpenTracingCollectorWithSqlLogger(tracer, ctx -> activeSpan));
+
+        // The actual Jdbi code:
+        {
+            Handle handle = dbi.open();
+            Query statement = handle.createQuery("SELECT COUNT(*) FROM accounts");
+            List<Map<String, Object>> results = statement.mapToMap().list();
+        }
+        activeSpan.finish();
+
+        // The finished spans should include the parent linkage via the ActiveSpanSource.
+        List<MockSpan> finishedSpans = tracer.finishedSpans();
+        assertEquals(finishedSpans.size(), 2);
+        MockSpan parentSpan = finishedSpans.get(1);
+        MockSpan childSpan = finishedSpans.get(0);
+        assertEquals("active span", parentSpan.operationName());
+        assertEquals("Jdbi Statement", childSpan.operationName());
+        assertEquals(parentSpan.context().traceId(), childSpan.context().traceId());
+        assertEquals(parentSpan.context().spanId(), childSpan.parentId());
+    }
+
+    @Test
+    public void testChainsToNext() {
+        MockTracer tracer = new MockTracer();
+        Jdbi dbi = getLocalJdbi("_jdbi_test_db");
+        Tracer.SpanBuilder parentBuilder = tracer.buildSpan("active span");
+
+        class TestTimingCollector implements SqlLogger {
+            boolean called = false;
+
+            @Override
+            public void logAfterExecution(StatementContext context) {
+                called = true;
+            }
+        }
+
+        TestTimingCollector subject = new TestTimingCollector();
+
+        final Span activeSpan = parentBuilder.start();
+        dbi.setSqlLogger(new OpenTracingCollectorWithSqlLogger(tracer, OpenTracingCollectorWithSqlLogger.SpanDecorator.DEFAULT,
+            ctx -> activeSpan,
+                subject)
+        );
+
+        // The actual Jdbi code:
+        {
+            Handle handle = dbi.open();
+            Query statement = handle.createQuery("SELECT COUNT(*) FROM accounts");
+            List<Map<String, Object>> results = statement.mapToMap().list();
+        }
+
+        activeSpan.finish();
+
+        assertTrue(subject.called);
+    }
+}


### PR DESCRIPTION
Added package jdbi3 for the jdbi3 classes.
I copied the OpenTracingCollector class with 2 versions:
1. Using TimingCollector - which is deprecated.
2. Using the SqlLogger (OpenTracingCollectorWithSqlLogger)

Tests updated for the SqlLogger only